### PR TITLE
feat: implement local JSON export/backup for all data tables

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,4 +23,6 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.31", features = ["bundled"] }
+chrono = "0.4.42"
+dirs = "6.0.0"
 

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -1,0 +1,87 @@
+use crate::db::get_connection;
+use rusqlite::Connection;
+use serde::Serialize;
+use std::fs;
+
+#[derive(Serialize)]
+struct BackupData {
+    customers: Vec<serde_json::Value>,
+    services: Vec<serde_json::Value>,
+    income: Vec<serde_json::Value>,
+    expenses: Vec<serde_json::Value>,
+    transactions: Vec<serde_json::Value>,
+    bank_accounts: Vec<serde_json::Value>,
+    bank_transactions: Vec<serde_json::Value>,
+    settings: Vec<serde_json::Value>,
+}
+
+use rusqlite::{types::ValueRef, Result};
+use serde_json::Value as JsonValue;
+
+fn fetch_all(conn: &Connection, table: &str) -> Result<Vec<JsonValue>, String> {
+    let mut stmt = conn
+        .prepare(&format!("SELECT * FROM {}", table))
+        .map_err(|e| e.to_string())?;
+
+    let column_names: Vec<String> = stmt.column_names().iter().map(|&s| s.to_string()).collect();
+
+    let rows = stmt
+        .query_map([], |row| {
+            let mut obj = serde_json::Map::new();
+            for (i, name) in column_names.iter().enumerate() {
+                let value_ref = row.get_ref(i)?;
+                let value = match value_ref {
+                    ValueRef::Null => JsonValue::Null,
+                    ValueRef::Integer(v) => JsonValue::from(v),
+                    ValueRef::Real(v) => JsonValue::from(v),
+                    ValueRef::Text(v) => {
+                        let text = String::from_utf8_lossy(v).to_string();
+                        JsonValue::from(text)
+                    }
+                    ValueRef::Blob(_) => JsonValue::String("[BLOB_DATA]".into()),
+                };
+                obj.insert(name.clone(), value);
+            }
+            Ok(JsonValue::Object(obj))
+        })
+        .map_err(|e| e.to_string())?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row.map_err(|e| e.to_string())?);
+    }
+
+    Ok(results)
+}
+
+#[tauri::command]
+pub fn export_backup() -> Result<String, String> {
+    let conn = get_connection().map_err(|e| e.to_string())?;
+
+    let data = BackupData {
+        customers: fetch_all(&conn, "customers")?,
+        services: fetch_all(&conn, "services")?,
+        income: fetch_all(&conn, "income")?,
+        expenses: fetch_all(&conn, "expenses")?,
+        transactions: fetch_all(&conn, "transactions")?,
+        bank_accounts: fetch_all(&conn, "bank_accounts")?,
+        bank_transactions: fetch_all(&conn, "bank_transactions")?,
+        settings: fetch_all(&conn, "settings")?,
+    };
+
+    let json = serde_json::to_string_pretty(&data).map_err(|e| e.to_string())?;
+
+    let mut path = dirs::document_dir().ok_or("Could not find documents directory")?;
+    path.push("Lumo");
+    path.push("backups");
+
+    fs::create_dir_all(&path).map_err(|e| e.to_string())?;
+    path.push(format!(
+        "backup_{}.json",
+        chrono::Local::now().format("%Y-%m-%d_%H-%M-%S")
+    ));
+
+    fs::write(&path, json).map_err(|e| e.to_string())?;
+
+    Ok(format!("Backup created at: {}", path.display()))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod services;
 mod bank;
 mod transactions; 
 mod settings;  
+mod backup;
 
 #[tauri::command]
 fn greet(name: &str) -> String {
@@ -38,6 +39,8 @@ pub fn run() {
             settings::get_settings,
             settings::reset_settings,
             settings::update_settings,
+
+            backup::export_backup,
 
         ])
         .run(tauri::generate_context!())


### PR DESCRIPTION
- Added new `backup.rs` module for full SQLite export to JSON
- Implemented `export_backup` command to serialize and save:
  • customers
  • services
  • income
  • expenses
  • transactions
  • bank_accounts
  • bank_transactions
  • settings
- Automatically saves to user's Documents/Lumo/backups with timestamped filename
- Handles directory creation and JSON formatting
- Added `chrono` and `dirs` crates for time and filesystem operations
- Fixed type conversion in `fetch_all()` using ValueRef for universal SQLite → JSON translation

This completes the Add local JSON export/backup function (#11)
and finalizes the Data Layer phase.
